### PR TITLE
Fix the ResolveUserName.sh to return right format userName without new line.

### DIFF
--- a/nodemanager/scripts/ResolveUserName.sh
+++ b/nodemanager/scripts/ResolveUserName.sh
@@ -61,7 +61,7 @@ fi
 #End of verify, which could be comment out for performance consideration.
 
 #Echo back the composedUserName
-echo "$composedUserName"
+echo -n "$composedUserName"
 
 exit 0
 


### PR DESCRIPTION
1. Make ResolveUserName.sh to return right format userName without a new line.